### PR TITLE
fix: change deploy strategy to multi-stage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,59 @@
 language: ruby
 sudo: required
 
-services:
-  - docker
-
 env:
   global:
-    - COMPOSE_FILE=docker-compose.yml
-    - secure: ojoixSpcynJiCdew7jvNOfCvEEip9F21QzovapQHgCFdQr+GJX16xPfrad7GrRqrq6o9xuzpQKMudYlAsh7bCauOjK9isE89r1TNz+dre2AonLp3Ble6DkW3eYvhJ9a7p/iRRqV5Ahu28/ivyMZ36vD5I5aHfYUwW7T5lk4p5F2tQDX44bMFGbi3ff3er6yDKvFQBgZMUPoBDLwyePqkXduwo25ncf6x/S0vRmecwx/tJDaY54OPwc8nbMuMF0NOah5q4+pl6oNENjpx9kKsOMJUYhDRvzQuPzo4rmogHoRQNPdBmcy1pjDPVMfAbcYhR08bnKbLgZW9nEE9Ob4CY8mETw8PtPQtURRR3jsYqKS+DUPMLSIMskhf8xlpxnOwVhalyIqChL//M5HmVfUeIxTgnSahge8MeU+uvN2quIOc/iHwdOHtz/KJSQg2jiBAlaKBwpySv4/SQB3M5SyrRrEvXZM95UeEdbogWWPOlD4CGH1Hy8OP2zi403omSP7zddVIihSCqo00nqT8UAb5Yo3FtM6ZISJZ7j0+QbGV0Bsm8KtRw5wNZCCIokVrLorXyUdBgfa3BLnRHgV8vo+JUFJ89nCPAySMgP3EEo66kPTCdZffthn8zM8R5OU+Qc5Za4m67y+/Q+jPXcaIwic0nOunmhTJst7iDpUq14Dzzlw=
+  - secure: ojoixSpcynJiCdew7jvNOfCvEEip9F21QzovapQHgCFdQr+GJX16xPfrad7GrRqrq6o9xuzpQKMudYlAsh7bCauOjK9isE89r1TNz+dre2AonLp3Ble6DkW3eYvhJ9a7p/iRRqV5Ahu28/ivyMZ36vD5I5aHfYUwW7T5lk4p5F2tQDX44bMFGbi3ff3er6yDKvFQBgZMUPoBDLwyePqkXduwo25ncf6x/S0vRmecwx/tJDaY54OPwc8nbMuMF0NOah5q4+pl6oNENjpx9kKsOMJUYhDRvzQuPzo4rmogHoRQNPdBmcy1pjDPVMfAbcYhR08bnKbLgZW9nEE9Ob4CY8mETw8PtPQtURRR3jsYqKS+DUPMLSIMskhf8xlpxnOwVhalyIqChL//M5HmVfUeIxTgnSahge8MeU+uvN2quIOc/iHwdOHtz/KJSQg2jiBAlaKBwpySv4/SQB3M5SyrRrEvXZM95UeEdbogWWPOlD4CGH1Hy8OP2zi403omSP7zddVIihSCqo00nqT8UAb5Yo3FtM6ZISJZ7j0+QbGV0Bsm8KtRw5wNZCCIokVrLorXyUdBgfa3BLnRHgV8vo+JUFJ89nCPAySMgP3EEo66kPTCdZffthn8zM8R5OU+Qc5Za4m67y+/Q+jPXcaIwic0nOunmhTJst7iDpUq14Dzzlw=
 
-script:
-  - ls -lah
-  - docker-compose run --rm ebook
-
-deploy:
-  - provider: script
-    api_key: "$GITHUB_TOKEN"
-    node_js: lts/*
-    skip_cleanup: true
-    script: npx semantic-release
-    on:
-      branch: master
-  - provider: releases
-    api_key: "$GITHUB_TOKEN"
-    file_glob: true
-    file: book-release/*
-    skip_cleanup: true
-    on:
-      tags: true
+jobs:
+  include:
+    - stage: "Semantic Release"
+      name: "Generate a new release and changelogs"
+      language: node_js
+      node_js: lts/*
+      os:
+      - linux
+      install:
+      - npm install
+      script:
+      - echo "default npm test ignored"
+      deploy:
+        provider: script
+        api_key: "$GITHUB_TOKEN"
+        node_js: lts/*
+        skip_cleanup: true
+        script: npx semantic-release
+        on:
+          branch: master
+    
+    - stage: "eBook Generation"
+      name: "Generates the ebook following the new release if it's applied"
+      services:
+      - docker
+      env:
+      - COMPOSE_FILE=docker-compose.yml
+      script:
+      - ls -lah
+      - git describe --tags --abbrev=0
+      - docker-compose run --rm ebook
+    
+    - stage: "GitHub Release"
+      name: "Send the generated files to the new GitHub release"
+      script: skip
+      deploy:
+        provider: releases
+        api_key: "$GITHUB_TOKEN"
+        file:
+        - "book-release/automated-ebook.epub"
+        - "book-release/automated-ebook.mobi"
+        - "book-release/automated-ebook.pdf"
+        skip_cleanup: true
+        on:
+          tags: true
 
 notifications:
   email:
     recipients:
-      - rcmoutinho@cyborgdeveloper.tech
+    - rcmoutinho@cyborgdeveloper.tech
     on_success: change
     on_failure: always


### PR DESCRIPTION
New attempt to make semantic-release work with Travis-CI and also
generate the ebook publishing on the generated release. This commit will
partially work on the develop branch to ensure Travis will accept the
new configuration and then fully tested after a merge.